### PR TITLE
support LWP 6.* instead of 6.0.*

### DIFF
--- a/lib/LWP/UserAgent/Patch/LogRequestContent.pm
+++ b/lib/LWP/UserAgent/Patch/LogRequestContent.pm
@@ -43,7 +43,7 @@ sub patch_data {
         patches => [
             {
                 action      => 'wrap',
-                mod_version => qr/^6\.0.*/,
+                mod_version => qr/^6\..*/,
                 sub_name    => 'simple_request',
                 code        => $p_simple_request,
             },


### PR DESCRIPTION
Hi,
I was unable to use your module with the current version of LWP without making this change.

Enjoy,
Jon
